### PR TITLE
Gutenberg fix

### DIFF
--- a/includes/class-ssp-speakers.php
+++ b/includes/class-ssp-speakers.php
@@ -180,24 +180,24 @@ class SSP_Speakers {
         );
 
 		// Build taxonomy arguments
-        $args = array(
-					'hierarchical' 					=> true,
-					'label' 								=> $this->plural,
-					'labels' 								=> apply_filters( 'ssp_speakers_taxonomy_labels', $labels ),
-					'meta_box_cb' 					=> null,
-					'public' 								=> true,
-					'query_var' 						=> $this->tax,
-					'rewrite' 							=> array( 
-						'slug' 								=> apply_filters( 'ssp_speakers_taxonomy_slug', $this->tax ) 
-					),
-					'show_admin_column'			=> true,
-					'show_in_nav_menus'			=> true,
-					'show_in_rest' 					=> true,
-					'show_tagcloud'					=> true,
-					'show_ui' 							=> true,
-					'sort' 									=> '',
-					'update_count_callback' => '',
-        );
+		$args = array(
+		  'hierarchical'          => true,
+		  'label'                 => $this->plural,
+		  'labels'                => apply_filters( 'ssp_speakers_taxonomy_labels', $labels ),
+		  'meta_box_cb'           => null,
+		  'public'                => true,
+		  'query_var'             => $this->tax,
+		  'rewrite'               => array( 
+		    'slug'                => apply_filters( 'ssp_speakers_taxonomy_slug', $this->tax ) 
+		  ),
+		  'show_admin_column'     => true,
+		  'show_in_nav_menus'     => true,
+		  'show_in_rest'          => true,
+		  'show_tagcloud'         => true,
+		  'show_ui'               => true,
+		  'sort'                  => '',
+		  'update_count_callback' => '',
+		);
 
         // Allow filtering of taxonomy arguments
         $args = apply_filters( 'ssp_register_taxonomy_args', $args, $this->tax );

--- a/includes/class-ssp-speakers.php
+++ b/includes/class-ssp-speakers.php
@@ -181,19 +181,22 @@ class SSP_Speakers {
 
 		// Build taxonomy arguments
         $args = array(
-        	'label' => $this->plural,
-        	'labels' => apply_filters( 'ssp_speakers_taxonomy_labels', $labels ),
-        	'hierarchical' => true,
-            'public' => true,
-            'show_ui' => true,
-            'show_in_nav_menus' => true,
-            'show_tagcloud' => true,
-            'meta_box_cb' => null,
-            'show_admin_column' => true,
-            'update_count_callback' => '',
-            'query_var' => $this->tax,
-            'rewrite' => array( 'slug' => apply_filters( 'ssp_speakers_taxonomy_slug', $this->tax ) ),
-            'sort' => '',
+					'hierarchical' 					=> true,
+					'label' 								=> $this->plural,
+					'labels' 								=> apply_filters( 'ssp_speakers_taxonomy_labels', $labels ),
+					'meta_box_cb' 					=> null,
+					'public' 								=> true,
+					'query_var' 						=> $this->tax,
+					'rewrite' 							=> array( 
+						'slug' 								=> apply_filters( 'ssp_speakers_taxonomy_slug', $this->tax ) 
+					),
+					'show_admin_column'			=> true,
+					'show_in_nav_menus'			=> true,
+					'show_in_rest' 					=> true,
+					'show_tagcloud'					=> true,
+					'show_ui' 							=> true,
+					'sort' 									=> '',
+					'update_count_callback' => '',
         );
 
         // Allow filtering of taxonomy arguments

--- a/includes/class-ssp-speakers.php
+++ b/includes/class-ssp-speakers.php
@@ -179,25 +179,25 @@ class SSP_Speakers {
             'items_list' => sprintf( __( '%s list' , 'seriously-simple-speakers' ), $this->plural ),
         );
 
-		// Build taxonomy arguments
-		$args = array(
-		  'hierarchical'          => true,
-		  'label'                 => $this->plural,
-		  'labels'                => apply_filters( 'ssp_speakers_taxonomy_labels', $labels ),
-		  'meta_box_cb'           => null,
-		  'public'                => true,
-		  'query_var'             => $this->tax,
-		  'rewrite'               => array( 
-		    'slug'                => apply_filters( 'ssp_speakers_taxonomy_slug', $this->tax ) 
-		  ),
-		  'show_admin_column'     => true,
-		  'show_in_nav_menus'     => true,
-		  'show_in_rest'          => true,
-		  'show_tagcloud'         => true,
-		  'show_ui'               => true,
-		  'sort'                  => '',
-		  'update_count_callback' => '',
-		);
+	// Build taxonomy arguments
+	$args = array(
+	  'hierarchical'          => true,
+	  'label'                 => $this->plural,
+	  'labels'                => apply_filters( 'ssp_speakers_taxonomy_labels', $labels ),
+	  'meta_box_cb'           => null,
+	  'public'                => true,
+	  'query_var'             => $this->tax,
+	  'rewrite'               => array( 
+	    'slug'                => apply_filters( 'ssp_speakers_taxonomy_slug', $this->tax ) 
+	  ),
+	  'show_admin_column'     => true,
+	  'show_in_nav_menus'     => true,
+	  'show_in_rest'          => true,
+	  'show_tagcloud'         => true,
+	  'show_ui'               => true,
+	  'sort'                  => '',
+	  'update_count_callback' => '',
+	);
 
         // Allow filtering of taxonomy arguments
         $args = apply_filters( 'ssp_register_taxonomy_args', $args, $this->tax );


### PR DESCRIPTION
This adds in the `show_in_rest` argument to the taxonomy creation which is necessary for Gutenberg to show the speaker panel, since it consumes the API for its functionality. I also just cleaned up up the code a little and sorted arguments alphabetically.